### PR TITLE
:art: :lipstick: Move cards information to profile bar

### DIFF
--- a/front-end/src/components/dashboard/dashboard-cards.js
+++ b/front-end/src/components/dashboard/dashboard-cards.js
@@ -1,47 +1,39 @@
 import React from 'react'
 import { Grid } from '@mui/material'
-import { AdminData as adminData } from '@/assets/menu'
 import { AiOutlineRight } from "react-icons/ai";
 
-
-const DashboardCards = () => {
+const DashboardCards = ({dashData, index}) => {
   return (
-    <Grid container spacing={1} className="my-4">
-        <Grid container spacing={2} className="mb-8">
-          {adminData().map((data, index) => (
-            <Grid key={index} item md={4} xs={12}>
-              <section
-                className={`${
-                  index === 1
-                    ? "bg-white shadow-xl"
-                    : "bg-card shadow-xl text-white "
-                } rounded h-[20vh]`}
-              >
-                <div className="p-2 h-[14vh] space-y-4">
-                  <p className="text-sm">{data.label}</p>
-                  <div className="flex items-center justify-between">
-                    <h1 className="font-semibold text-xl">{data.number}</h1>
-                    <div className="flex items-center">
-                      <p className="text-xs font-thin underline">
-                        {data?.waiting} {data?.status}
-                      </p>
-                      <AiOutlineRight />
-                    </div>
-                  </div>
-                </div>
-                <div
-                  className={`${
-                    index === 1 ? "bg-background" : "bg-cardSecondary "
-                  } rounded-br rounded-bl h-[6vh] p-2 flex items-center justify-between text-xs font-thin`}
-                >
-                  <p>{data.condition}</p>
-                  <p>{data.condition_number}</p>
-                </div>
-              </section>
-            </Grid>
-          ))}
-        </Grid>
-      </Grid>
+    <Grid item md={4} xs={12}>
+      <section
+        className={`${
+          index === 1
+            ? "bg-white shadow-xl"
+            : "bg-card shadow-xl text-white "
+        } rounded h-[10vh]`}
+        >
+        <div className="p-1 h-[8vh] space-y-0">
+          <p className="text-sm">{dashData?.label}</p>
+          <div className="flex items-center justify-between">
+            <h1 className="font-semibold text-xl">{dashData?.number}</h1>
+            <div className="flex items-center">
+              <p className="text-xs font-thin underline">
+                {dashData?.waiting} {dashData?.status}
+              </p>
+              <AiOutlineRight />
+            </div>
+          </div>
+        </div>
+        <div
+          className={`${
+            index === 1 ? "bg-background" : "bg-cardSecondary "
+          } rounded-br rounded-bl h-[4vh] p-2 flex items-center justify-between text-xs font-thin`}
+        >
+          <p>{dashData?.condition}</p>
+          <p>{dashData?.condition_number}</p>
+        </div>
+      </section>
+    </Grid>
   )
 }
 

--- a/front-end/src/components/layout/customized-header.js
+++ b/front-end/src/components/layout/customized-header.js
@@ -1,4 +1,4 @@
-import { Container } from "@mui/material";
+import { Container, Grid } from "@mui/material";
 import React, { useContext, useState } from "react";
 import { AiOutlineMenu } from "react-icons/ai";
 import { Drawer } from "@/assets/drawer";
@@ -8,6 +8,9 @@ import { BsChevronDown } from "react-icons/bs";
 import { authContext } from "../use-context";
 import { useAuth } from "@/assets/hooks/use-auth";
 import { FaUserCircle } from "react-icons/fa";
+import { AdminData as adminData } from '@/assets/menu'
+import DashboardCards from "../dashboard/dashboard-cards";
+
 
 const CustomizedHeader = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -25,9 +28,11 @@ const CustomizedHeader = () => {
     setAnchorEl(null);
   };
 
+  const dashboardCards = adminData().map((data, index)=> <DashboardCards dashData={data} index={index} key={`dashboard-card-${index}`}/>)
+
   return (
     <>
-      <section className="sticky top-0 py-4 bg-primary shadow-xl h-[10vh]">
+      <section className="sticky top-0 py-2 md:p-0 bg-white shadow-sm h-[10vh] md:h-[15vh]">
         <Container maxWidth="xl">
           <section className="flex items-center md:justify-end justify-between gap-4">
             <div className="md:hidden block">
@@ -37,12 +42,17 @@ const CustomizedHeader = () => {
               />
               <Drawer {...{ isOpen, setIsOpen }} />
             </div>
+            <Grid container spacing={1} className="my-2 hidden md:block">
+              <Grid container spacing={2}>
+                {dashboardCards}
+              </Grid>
+            </Grid>
             <div className="flex items-center gap-2">
-              <FaUserCircle className="w-6 h-6 text-white" />
-              <span className="text-white text-sm">{token?.first_name}</span>
+              <FaUserCircle className="w-6 h-6 text-primary" />
+              <span className="text-primary text-sm">{token?.first_name}</span>
               <BsChevronDown
                 onClick={handleClick}
-                className="text-white cursor-pointer"
+                className="text-primary cursor-pointer"
               />
             </div>
             <Menu

--- a/front-end/src/components/layout/header.js
+++ b/front-end/src/components/layout/header.js
@@ -1,26 +1,37 @@
-import { Container } from "@mui/material";
+import { Container, Grid } from "@mui/material";
 import React, { useState } from "react";
 import TopSection from "./rightbar/top-section";
 import AddPatientModal from "../dashboard/patient/add-patient-modal";
 import { AiOutlineMenu } from "react-icons/ai";
 import { Drawer } from "@/assets/drawer";
 import Link from "next/link";
+import { AdminData as adminData } from '@/assets/menu'
+import DashboardCards from "../dashboard/dashboard-cards";
 
 const Header = () => {
   const [isOpen, setIsOpen] = useState(false);
 
+  const dashboardCards = adminData().map((data, index)=> <DashboardCards dashData={data} index={index} key={`dashboard-card-${index}`}/>)
+
+
   return (
     <>
       <Drawer {...{ isOpen, setIsOpen }} />
-      <section className="sticky top-0 py-2 bg-primary h-[10vh] shadow-xl mb-12">
+      <section className="sticky top-0 py-2 md:p-0 bg-white h-[10vh] md:h-[15vh] shadow-sm mb-12">
         <Container maxWidth="xl">
           <section className="flex items-center justify-between gap-4">
-            <div className="md:hidden block">
+            <div className="md:hidden block bg-red">
               <AiOutlineMenu
                 className="text-2xl text-white cursor-pointer"
                 onClick={() => setIsOpen(true)}
               />
             </div>
+
+            <Grid container spacing={1} className="my-2 hidden md:block">
+              <Grid container spacing={2}>
+                {dashboardCards}
+              </Grid>
+            </Grid>
 
             <div className="md:hidden block">
               <TopSection />

--- a/front-end/src/components/layout/sidebar/index.js
+++ b/front-end/src/components/layout/sidebar/index.js
@@ -12,7 +12,7 @@ const Sidebar = () => {
   return (
     <>
       <section className="">
-        <header className="h-[10vh] shadow flex items-center justify-center font-bold">
+        <header className="h-[15vh] shadow flex items-center justify-center font-bold">
           <h1>Logo</h1>
         </header>
         <section className="pl-2 h-[84vh] flex flex-col justify-between">

--- a/front-end/src/pages/dashboard/doctor-interface/index.js
+++ b/front-end/src/pages/dashboard/doctor-interface/index.js
@@ -2,14 +2,12 @@ import React from "react";
 import CustomizedLayout from "@/components/layout/customized-layout";
 import { Container } from "@mui/material";
 import DoctorPatientDataGrid from "@/components/dashboard/doctor-interface/doctor-patient-datagrid";
-import DashboardCards from "@/components/dashboard/dashboard-cards";
 import AuthGuard from "@/assets/hoc/auth-guard";
 import ProtectedRoute from "@/assets/hoc/protected-route";
 
 const DoctorInterface = () => {
   return (
     <Container maxWidth="xl" className="mt-8">
-      <DashboardCards />
       <DoctorPatientDataGrid />
     </Container>
   );

--- a/front-end/src/pages/dashboard/index.js
+++ b/front-end/src/pages/dashboard/index.js
@@ -12,7 +12,6 @@ const Dashboard = () => {
   console.log("USER_PERMISSIONS ",userPermissions)
   return (
     <Container maxWidth="xl">
-      <DashboardCards />
       <PatientsDataGrid />
     </Container>
   );

--- a/front-end/src/pages/dashboard/nursing-interface/index.js
+++ b/front-end/src/pages/dashboard/nursing-interface/index.js
@@ -2,14 +2,12 @@ import React from "react";
 import CustomizedLayout from "@/components/layout/customized-layout";
 import { Container } from "@mui/material";
 import AuthGuard from "@/assets/hoc/auth-guard";
-import DashboardCards from "@/components/dashboard/dashboard-cards";
 import NursePatientDataGrid from '@/components/dashboard/nursing-interface';
 
 
 const NursingInterface = () => {
   return (
-    <Container maxWidth="xl">
-      <DashboardCards />
+    <Container maxWidth="xl mt-8">
       <NursePatientDataGrid />
     </Container>
   );

--- a/front-end/src/pages/dashboard/reception-interface/index.js
+++ b/front-end/src/pages/dashboard/reception-interface/index.js
@@ -2,7 +2,6 @@ import React from "react";
 import CustomizedLayout from "@/components/layout/customized-layout";
 import { Container } from "@mui/material";
 import PatientAppointmentDataGrid from "@/components/dashboard/reception-interface/patient-appointment-datagrid";
-import DashboardCards from "@/components/dashboard/dashboard-cards";
 import AuthGuard from "@/assets/hoc/auth-guard";
 import { getAllPatientAppointments } from "@/redux/features/appointment";
 import { useDispatch, useSelector } from "react-redux";
@@ -20,7 +19,6 @@ const ReceptionInterface = () => {
 
   return (
     <Container maxWidth="xl" className="mt-8">
-      <DashboardCards />
       <PatientAppointmentDataGrid {...{ patientAppointments }} />
     </Container>
   );


### PR DESCRIPTION
this pr moves the dashboad cards to the top navigation bar. 

fixes #315 

![Screenshot from 2023-12-31 15-59-25](https://github.com/PROTO-TYPE-SOLUTIONS/make-easy-hmis/assets/71401172/0cb34173-5ba3-467a-bfc4-e1aa1366be3a)
